### PR TITLE
feat(Planner): support direct swaps with ether

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,11 +56,14 @@ To swap directly with Ether (native token, **NOT ERC20**):
 >>> uni.swap(want="UNI", sender=trader, value="1 ether")
 # OR
 >>> uni.swap(want="UNI", amount_out="10 UNI", sender=trader, value="1 ether")
+# OR
+>>> uni.swap(have="UNI", amount_in="10 UNI", native_out=True, ...)
 ```
 
 If `have=` is not present but `value=` is, then `have=` will be set to WETH (if available on your network) for solving.
 If `amount_in=`, `max_amount_in=`, and `amount_out=` are not present (1st example), then `value=` will work like `amount_in=`.
 If `amount_out` is present (2nd example), then `value=` will act like setting `max_amount_in=`.
+If `native_out=True` is present (3rd example), then the amount received will be native ether and not an ERC20.
 
 ### CLI
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,18 @@ Decimal("4.75")
 ... )
 ```
 
+To swap directly with Ether (native token, **NOT ERC20**):
+
+```py
+>>> uni.swap(want="UNI", sender=trader, value="1 ether")
+# OR
+>>> uni.swap(want="UNI", amount_out="10 UNI", sender=trader, value="1 ether")
+```
+
+If `have=` is not present but `value=` is, then `have=` will be set to WETH (if available on your network) for solving.
+If `amount_in=`, `max_amount_in=`, and `amount_out=` are not present (1st example), then `value=` will work like `amount_in=`.
+If `amount_out` is present (2nd example), then `value=` will act like setting `max_amount_in=`.
+
 ### CLI
 
 This SDK installs a special CLI command `uni`.

--- a/uniswap_sdk/main.py
+++ b/uniswap_sdk/main.py
@@ -58,7 +58,7 @@ class Uniswap(ManagerAccessMixin):
         use_solver: SolverType | None = None,
     ):
         if default_slippage is not None:
-            self.DEFAULT_SLIPPAGE = Decimal(default_slippage)
+            self.DEFAULT_SLIPPAGE = Decimal(default_slippage).quantize(Decimal("1e-5"))
 
         self.permit2 = Permit2()
         self.router = ur.UniversalRouter()

--- a/uniswap_sdk/main.py
+++ b/uniswap_sdk/main.py
@@ -275,6 +275,8 @@ class Uniswap(ManagerAccessMixin):
         order: Order | None = None,
         routes: Iterable[Route] | None = None,
         permit_step: ur.Command | None = None,
+        native_in: bool = False,
+        native_out: bool = False,
         receiver: "str | BaseAddress | AddressType | None" = None,
         **order_kwargs,
     ) -> ur.Plan:
@@ -297,6 +299,8 @@ class Uniswap(ManagerAccessMixin):
             order,
             solution,
             permit_step=permit_step,
+            native_in=native_in,
+            native_out=native_out,
             receiver=receiver,
         )
 
@@ -322,8 +326,10 @@ class Uniswap(ManagerAccessMixin):
         order: Order | None = None,
         routes: Iterable[Route] | None = None,
         receiver: "str | BaseAddress | AddressType | None" = None,
+        native_out: bool = False,
         as_transaction: bool = False,
         deadline: timedelta | None = None,
+        value: str | int | None = None,
         **order_and_txn_kwargs,
     ) -> "ReceiptAPI | TransactionAPI":
         order_kwargs: dict = dict()
@@ -333,49 +339,64 @@ class Uniswap(ManagerAccessMixin):
                 if field in order_and_txn_kwargs:
                     order_kwargs[field] = order_and_txn_kwargs.pop(field)
 
+            if value:
+                order_kwargs["have"] = "WETH"
+
+                if "amount_out" in order_kwargs and "max_amount_in" not in order_kwargs:
+                    order_kwargs["max_amount_in"] = self.conversion_manager.convert(value, int)
+
+                elif "amount_in" not in order_kwargs:
+                    order_kwargs["amount_in"] = self.conversion_manager.convert(value, int)
+
+            if native_out or order_kwargs.get("want") == "ether":
+                order_kwargs["want"] = "WETH"
+                native_out = True
+
             order = self.create_order(**order_kwargs)
 
-        have = order.have_token if order else order_and_txn_kwargs.get("have", order_kwargs["have"])
-        if not isinstance(have, TokenInstance):
-            have = Token.at(self.conversion_manager.convert(have, AddressType))
-
-        from ape.api import AccountAPI
-
         permit_step = None
-        if not isinstance(sender := order_and_txn_kwargs.get("sender"), AccountAPI):
-            logger.warning("No `sender` present to sign permits with")
+        if not value:
+            from ape.api import AccountAPI
 
-        elif have.allowance(sender, self.permit2.contract) < (
-            amount := order.amount_in if isinstance(order, ExactInOrder) else order.max_amount_in
-        ):
-            logger.warning(
-                f"Permit2 '{self.permit2.contract}' needs approval from '{sender}' "
-                f"to spend at least {amount} {have.symbol()}."
-            )
+            if not isinstance(sender := order_and_txn_kwargs.get("sender"), AccountAPI):
+                logger.warning("No `sender` present to sign permits with")
 
-        else:
-            expiration = datetime.now(timezone.utc) + (deadline or timedelta(minutes=2))
-            permit_step = self.permit2.sign_permit(
-                spender=self.router.contract,
-                permit=PermitDetails(  # type: ignore[call-arg]
-                    token=have.address,
-                    amount=int(amount * 10 ** have.decimals()),
-                    expiration=int(expiration.timestamp()),
-                    nonce=self.permit2.get_nonce(sender, have, self.router.contract),
-                ),
-                signer=sender,
-            )
+            elif order.have_token.allowance(sender, self.permit2.contract) < (
+                amount := (
+                    order.amount_in if isinstance(order, ExactInOrder) else order.max_amount_in
+                )
+            ):
+                logger.warning(
+                    f"Permit2 '{self.permit2.contract}' needs approval from '{sender}' "
+                    f"to spend at least {amount} {order.have_token.symbol()}."
+                )
+
+            else:
+                expiration = datetime.now(timezone.utc) + (deadline or timedelta(minutes=2))
+                permit_step = self.permit2.sign_permit(
+                    spender=self.router.contract,
+                    permit=PermitDetails(  # type: ignore[call-arg]
+                        token=order.have,
+                        amount=int(amount * 10 ** order.have_token.decimals()),
+                        expiration=int(expiration.timestamp()),
+                        nonce=self.permit2.get_nonce(sender, order.have, self.router.contract),
+                    ),
+                    signer=sender,
+                )
 
         plan = self.create_plan(
             order=order,
             routes=routes,
             permit_step=permit_step,
+            native_in=bool(value),
+            native_out=native_out,
             receiver=receiver,
             **order_kwargs,
         )
 
-        if as_transaction:
-            return self.router.plan_as_transaction(plan, deadline=deadline, **order_and_txn_kwargs)
-
-        else:
-            return self.router.execute(plan, deadline=deadline, **order_and_txn_kwargs)
+        return (self.router.plan_as_transaction if as_transaction else self.router.execute)(
+            plan,
+            deadline=deadline,
+            value=value,
+            **order_and_txn_kwargs,
+        )

--- a/uniswap_sdk/main.py
+++ b/uniswap_sdk/main.py
@@ -224,7 +224,7 @@ class Uniswap(ManagerAccessMixin):
 
             else:  # NOTE: Compute slippage (for solver) based on provided inputs
                 slippage = (
-                    (price := self.price(have, want) - amount_out / max_amount_in) / price
+                    ((price := self.price(have, want)) - amount_out / max_amount_in) / price
                 ).quantize(Decimal("1e-5"))
 
             return ExactOutOrder(
@@ -242,7 +242,7 @@ class Uniswap(ManagerAccessMixin):
 
             else:  # NOTE: Compute slippage (for solver) based on provided inputs
                 slippage = (
-                    (price := self.price(have, want) - min_amount_out / amount_in) / price
+                    ((price := self.price(have, want)) - min_amount_out / amount_in) / price
                 ).quantize(Decimal("1e-5"))
 
             return ExactInOrder(

--- a/uniswap_sdk/solver.py
+++ b/uniswap_sdk/solver.py
@@ -110,6 +110,8 @@ def convert_solution_to_plan(
     order: Order,
     solution: Solution,
     permit_step: ur.Command | None = None,
+    native_in: bool = False,
+    native_out: bool = False,
     receiver: AddressType | None = None,
 ) -> ur.Plan:
     ONE_HAVE_TOKEN = 10 ** order.have_token.decimals()
@@ -120,14 +122,18 @@ def convert_solution_to_plan(
     total_amount_out = order.min_amount_out if use_exact_in else order.amount_out
 
     plan = ur.Plan()
-    if permit_step:
+    if native_in:
+        plan = plan.wrap_eth(ur.Constants.ADDRESS_THIS, int(total_amount_in * 10**18))
+
+    elif permit_step:
         plan = plan.add(permit_step)
 
     # TODO: Add donation support
+
     if receiver is None:
         receiver = ur.Constants.MSG_SENDER
 
-    payer_is_user = True  # False = Payer is Router
+    payer_is_user = not native_in  # False = Payer is Router
 
     for route, flow_ratio in solution.items():
         # Percentage of `total_amount_in/_out` that should come from this swap
@@ -137,7 +143,7 @@ def convert_solution_to_plan(
         if all(isinstance(p, v3.Pool) for p in route):
             if use_exact_in:
                 plan = plan.v3_swap_exact_in(
-                    receiver,
+                    ur.Constants.ADDRESS_THIS if native_out else receiver,
                     int(amount_in_route * ONE_HAVE_TOKEN),  # amountIn
                     int(amount_out_route * ONE_WANT_TOKEN),  # amountOutMin
                     v3.Factory.encode_route(order.have_token, *route),
@@ -146,7 +152,7 @@ def convert_solution_to_plan(
 
             else:
                 plan = plan.v3_swap_exact_out(
-                    receiver,
+                    ur.Constants.ADDRESS_THIS if native_out else receiver,
                     int(amount_out_route * ONE_WANT_TOKEN),  # amountOut
                     int(amount_in_route * ONE_HAVE_TOKEN),  # amountInMax
                     v3.Factory.encode_route(order.have_token, *route),
@@ -156,7 +162,7 @@ def convert_solution_to_plan(
         elif all(isinstance(p, v2.Pair) for p in route):
             if use_exact_in:
                 plan = plan.v2_swap_exact_in(
-                    receiver,
+                    ur.Constants.ADDRESS_THIS if native_out else receiver,
                     int(amount_in_route * ONE_HAVE_TOKEN),  # amountIn
                     int(amount_out_route * ONE_WANT_TOKEN),  # amountOutMin
                     v2.Factory.encode_route(order.have_token, *route),
@@ -165,7 +171,7 @@ def convert_solution_to_plan(
 
             else:
                 plan = plan.v2_swap_exact_out(
-                    receiver,
+                    ur.Constants.ADDRESS_THIS if native_out else receiver,
                     int(amount_out_route * ONE_WANT_TOKEN),  # amountOut
                     int(amount_in_route * ONE_HAVE_TOKEN),  # amountInMax
                     v2.Factory.encode_route(order.have_token, *route),
@@ -175,5 +181,8 @@ def convert_solution_to_plan(
         else:
             # NOTE: Should never happen
             raise ValueError(f"Invalid route: {route}")
+
+    if native_in or native_out:
+        plan = plan.unwrap_weth(receiver, int(total_amount_out * 10**18))
 
     return plan

--- a/uniswap_sdk/solver.py
+++ b/uniswap_sdk/solver.py
@@ -155,7 +155,8 @@ def convert_solution_to_plan(
                     ur.Constants.ADDRESS_THIS if native_out else receiver,
                     int(amount_out_route * ONE_WANT_TOKEN),  # amountOut
                     int(amount_in_route * ONE_HAVE_TOKEN),  # amountInMax
-                    v3.Factory.encode_route(order.have_token, *route),
+                    # NOTE: For v3, exact out swap must be encoded in reverse order
+                    v3.Factory.encode_route(order.want_token, *reversed(route)),
                     payer_is_user,
                 )
 

--- a/uniswap_sdk/solver.py
+++ b/uniswap_sdk/solver.py
@@ -183,7 +183,10 @@ def convert_solution_to_plan(
             # NOTE: Should never happen
             raise ValueError(f"Invalid route: {route}")
 
-    if native_in or native_out:
+    if native_in:
+        plan = plan.unwrap_weth(receiver, 0)  # NOTE: In case of any extra
+
+    elif native_out:
         plan = plan.unwrap_weth(receiver, int(total_amount_out * 10**18))
 
     return plan


### PR DESCRIPTION
### What I did

Currently, it is not possible to directly perform a swap where the first step in the plan is to wrap ether to perform the swap as WETH. This PR fixes that

### How I did it

### How to verify it

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [x] Documentation has been updated
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
