### PR TITLE
feat(Bots): example arbitrage bot (also useful for testnets)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,10 +6,6 @@ on:
   release:
     type: [published]
 
-env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ApeWorX/uniswap
-
 jobs:
   bots:
     runs-on: ubuntu-latest
@@ -24,6 +20,5 @@ jobs:
         with:
             push: ${{ github.event_name != 'pull_request' }}
             tag:  ${{ github.event_name == 'release' && 'stable' || 'latest' }}
-            registry: ghcr.io
             username: ${{ github.actor }}
             password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,7 +8,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
+  IMAGE_NAME: ApeWorX/uniswap
 
 jobs:
   bots:

--- a/bots/README.md
+++ b/bots/README.md
@@ -42,3 +42,108 @@ Defaults to every minute on the minute (e.g. **:**:00).
 #### `{base}/{quote}`
 
 The price for the token `{base}` in terms of the token `{quote}`.
+
+## Arbitrage
+
+The Arbitrage bot will monitor for price divergences from the given reference price, and buy tokens until the market price is back in line with it.
+
+> [!IMPORTANT]
+> This bot is not designed nor intended for production use.
+> It is meant to serve as an example that you can use when designing your own.
+
+> [!NOTE]
+> This bot can be used on public testnets in order to bring activity to Uniswap deployments that would otherwise not have any due to lack of economic incentives.
+
+### Configuration
+
+#### `TOKENA`
+
+_required_
+
+The first token symbol or address to perform arbitrage with.
+Used as the quote token when measuring the market price [`price`](#price).
+
+#### `TOKENB`
+
+_required_
+
+The second token symbol or address to perform arbitrage with.
+Used as the base token when measuring the market price [`price`](#price).
+
+#### `INTERMEDIATE_TOKENS`
+
+_optional_
+
+A comma-separated list of token symbols and/or addresses to use when indexing uniswap.
+Defaults to the configured tokenlist.
+
+#### `REFERENCE_PRICE`
+
+_optional_
+
+The reference price to use in order to compare to the [market price](#price) for arbitrage oppurtunities.
+Defaults to a reference price of 1:1 (good for stablecoin pairs).
+
+> [!IMPORTANT]
+> Besides stablecoins, it is not a good idea in practice to use a
+> static reference price to perform arbitrage.
+
+#### `ARBITRAGE_THRESHOLD`
+
+_optional_
+
+The threshold of divergence of the [market price](#price) from the
+[reference price](#reference_price) required to trigger an arbitrage.
+
+Defaults to 2.5%.
+
+#### `MAX_SWAP_SIZE_TOKENA`
+
+_optional_
+
+The maximum amount of [`TOKENA`](#tokena) to sell in any one trade.
+
+Defaults to full inventory size.
+
+#### `MAX_SWAP_SIZE_TOKENB`
+
+_optional_
+
+The maximum amount of [`TOKENB`](#tokena) to sell in any one trade.
+
+Defaults to full inventory size.
+
+`USE_PRIVATE_MEMPOOL`
+
+_optional_
+
+Whether to use a "private mempool" to submit the trade.
+Requires configuring a supported provider through Ape.
+
+Defaults to False.
+
+> [!IMPORTANT]
+> Certain networks leak public mempool activity to MEV searchers,
+> who can sandwich your trades in order to extract value from it.
+> Please use this bot carefully!
+
+#### `MEASUREMENT_CRON`
+
+_optional_
+
+A cron-spec used for triggering the token measurements.
+Defaults to every 5 minutes on the minute (e.g. **:**:05).
+
+### Metrics
+
+#### `{TOKENA.symbol()}`
+
+The amount of inventory the bot account has for [`TOKENA`](#tokena).
+
+#### `{TOKENB.symbol()}`
+
+The amount of inventory the bot account has for [`TOKENB`](#tokenb).
+
+#### `price`
+
+The price of [`TOKENA`](#tokena) in terms of the [`TOKENB`](#tokenb).

--- a/bots/arbitrage.py
+++ b/bots/arbitrage.py
@@ -66,14 +66,14 @@ async def rm_inventory_tokenB(log):
 
 
 @bot.cron(os.environ.get("MEASUREMENT_CRON", "*/5 * * * *"))
-async def current_price(_):
+async def price(_):
     return uni.price(TOKENA, TOKENB)
 
 
-@bot.on_metric("current_price")
-async def price_delta(current_price: Decimal):
+@bot.on_metric("price")
+async def price_delta(price: Decimal):
     # NOTE: Have a more accurate reference model in production use
-    return current_price - REFERENCE_PRICE
+    return price - REFERENCE_PRICE
 
 
 @bot.on_metric("price_delta", lt=-ARB_THRESHOLD)

--- a/bots/arbitrage.py
+++ b/bots/arbitrage.py
@@ -65,7 +65,7 @@ async def rm_inventory_tokenB(log):
     return {TOKENB.symbol(): bot.state.inventory[TOKENB]}
 
 
-@bot.cron("* * * * *")
+@bot.cron(os.environ.get("MEASUREMENT_CRON", "*/5 * * * *"))
 async def current_price(_):
     return uni.price(TOKENA, TOKENB)
 

--- a/bots/arbitrage.py
+++ b/bots/arbitrage.py
@@ -1,0 +1,108 @@
+import os
+from decimal import Decimal
+
+from ape.exceptions import ContractLogicError
+from ape_tokens import tokens
+from silverback import SilverbackBot
+
+from uniswap_sdk import Uniswap
+
+bot = SilverbackBot(signer_required=True)
+uni = Uniswap()
+
+TOKENA = tokens[os.environ.get("TOKENA", "USDT")]
+TOKENB = tokens[os.environ.get("TOKENB", "USDC")]
+
+if intermediate_tokens := os.environ.get("INTERMEDIATE_TOKENS"):
+    uni.install(bot, tokens=[TOKENA, *intermediate_tokens.split(","), TOKENB])
+
+else:
+    uni.install(bot, tokens=tokens)
+
+REFERENCE_PRICE = Decimal(os.environ.get("REFERENCE_PRICE", 1))
+ARB_THRESHOLD = Decimal(os.environ.get("ARBITRAGE_THRESHOLD", "0.025")) * REFERENCE_PRICE
+MAX_SWAP_SIZE_TOKENA = Decimal(os.environ.get("MAX_SWAP_SIZE_TOKENA", "inf"))
+MAX_SWAP_SIZE_TOKENB = Decimal(os.environ.get("MAX_SWAP_SIZE_TOKENB", "inf"))
+
+
+@bot.on_startup()
+async def fetch_balaces(_ss):
+    bot.state.inventory = {
+        TOKENA: Decimal(TOKENA.balanceOf(bot.signer)) / Decimal(10 ** TOKENA.decimals()),
+        TOKENB: Decimal(TOKENB.balanceOf(bot.signer)) / Decimal(10 ** TOKENB.decimals()),
+    }
+
+    return {
+        TOKENA.symbol(): bot.state.inventory[TOKENA],
+        TOKENB.symbol(): bot.state.inventory[TOKENB],
+    }
+
+
+# NOTE: Monitor inventory so we have it in memory
+@bot.on_(TOKENA.Transfer, receiver=bot.signer)
+async def add_inventory_tokenA(log):
+    bot.state.inventory[TOKENA] += Decimal(log.amount) / Decimal(10 ** TOKENA.decimals())
+    return {TOKENA.symbol(): bot.state.inventory[TOKENA]}
+
+
+@bot.on_(TOKENA.Transfer, sender=bot.signer)
+async def rm_inventory_tokenA(log):
+    bot.state.inventory[TOKENA] -= Decimal(log.amount) / Decimal(10 ** TOKENA.decimals())
+    return {TOKENA.symbol(): bot.state.inventory[TOKENA]}
+
+
+@bot.on_(TOKENA.Transfer, receiver=bot.signer)
+async def add_inventory_tokenB(log):
+    bot.state.inventory[TOKENB] += Decimal(log.amount) / Decimal(10 ** TOKENB.decimals())
+    return {TOKENB.symbol(): bot.state.inventory[TOKENB]}
+
+
+@bot.on_(TOKENA.Transfer, sender=bot.signer)
+async def rm_inventory_tokenB(log):
+    bot.state.inventory[TOKENB] -= Decimal(log.amount) / Decimal(10 ** TOKENB.decimals())
+    return {TOKENB.symbol(): bot.state.inventory[TOKENB]}
+
+
+@bot.cron("* * * * *")
+async def current_price(_):
+    return uni.price(TOKENA, TOKENB)
+
+
+@bot.on_metric("current_price")
+async def price_delta(current_price: Decimal):
+    # NOTE: Have a more accurate reference model in production use
+    return current_price - REFERENCE_PRICE
+
+
+@bot.on_metric("price_delta", lt=-ARB_THRESHOLD)
+async def buy(_):
+    # NOTE: Scale buys in production use
+    if (sell_amount := min(MAX_SWAP_SIZE_TOKENB, bot.state.inventory[TOKENB])) > 0:
+        try:
+            uni.swap(
+                have=TOKENB,
+                want=TOKENA,
+                amount_in=sell_amount,
+                min_amount_out=sell_amount * REFERENCE_PRICE,
+                sender=bot.signer,
+            )
+
+        except ContractLogicError:
+            pass
+
+
+@bot.on_metric("price_delta", gt=ARB_THRESHOLD)
+async def sell(_):
+    # NOTE: Scale sells in production use
+    if (sell_amount := min(MAX_SWAP_SIZE_TOKENA, bot.state.inventory[TOKENA])) > 0:
+        try:
+            uni.swap(
+                have=TOKENA,
+                want=TOKENB,
+                amount_in=sell_amount,
+                min_amount_out=sell_amount * REFERENCE_PRICE,
+                sender=bot.signer,
+            )
+
+        except ContractLogicError:
+            pass

--- a/bots/arbitrage.py
+++ b/bots/arbitrage.py
@@ -24,9 +24,11 @@ ARB_THRESHOLD = Decimal(os.environ.get("ARBITRAGE_THRESHOLD", "0.025")) * REFERE
 MAX_SWAP_SIZE_TOKENA = Decimal(os.environ.get("MAX_SWAP_SIZE_TOKENA", "inf"))
 MAX_SWAP_SIZE_TOKENB = Decimal(os.environ.get("MAX_SWAP_SIZE_TOKENB", "inf"))
 
+USE_PRIVATE_MEMPOOL = bool(os.environ.get("USE_PRIVATE_MEMPOOL", False))
+
 
 @bot.on_startup()
-async def fetch_balaces(_ss):
+async def load_inventory(_ss):
     bot.state.inventory = {
         TOKENA: Decimal(TOKENA.balanceOf(bot.signer)) / Decimal(10 ** TOKENA.decimals()),
         TOKENB: Decimal(TOKENB.balanceOf(bot.signer)) / Decimal(10 ** TOKENB.decimals()),
@@ -85,6 +87,7 @@ async def buy(_):
                 amount_in=sell_amount,
                 min_amount_out=sell_amount * REFERENCE_PRICE,
                 sender=bot.signer,
+                private=USE_PRIVATE_MEMPOOL,
             )
 
         except ContractLogicError:
@@ -102,6 +105,7 @@ async def sell(_):
                 amount_in=sell_amount,
                 min_amount_out=sell_amount * REFERENCE_PRICE,
                 sender=bot.signer,
+                private=USE_PRIVATE_MEMPOOL,
             )
 
         except ContractLogicError:


### PR DESCRIPTION
### What I did

I wanted to add a nice example of an arb bot for people to use, also kind of harkens to cHaOSneT where we wanted to have some protocol examples to sim with (or just run on public testnets)

~~requires: #17~~
~~requires: https://github.com/ApeWorX/silverback/pull/275~~
~~requires: https://github.com/ApeWorX/silverback/issues/276~~

### How I did it

### How to verify it

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
~~- [ ] New test cases have been added and are passing~~
~~- [ ] Documentation has been updated~~
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
